### PR TITLE
Add support of correct error handling for points writes which are beyond current rp

### DIFF
--- a/influx-backup.py
+++ b/influx-backup.py
@@ -177,7 +177,10 @@ def write_points(db, lines, chunk_delay):
             r = requests.post(URL+'/write', auth=AUTH, params=params, data=data)
             if r.status_code == 204:
                 return
-            last_error = ' %s HTTP error' % r.status_code
+            """InfluxDB is able to skip point beyond rp you write to"""
+            if 'points beyond retention policy' in r.text:
+                return
+            last_error = ' %s HTTP error, %s' % (r.status_code, r.text)
         except:
             last_error = sys.exc_info()[0]
         retries -= 1


### PR DESCRIPTION
Hi!
Thanks for your scripts. They met our needs.

But there are several things to improve. Here are they:

- your dumped retention policy duration might be longer than RP you're restoring to, e.g. 

| name |      duration | shardGroupDuration | replicaN | default |
| ---- | -------- | ------------------ | --------| ------- |
|dumped_rp| 672h0m0s| 24h0m0s|           1|        true|
|restoring_rp|    48h0m0s|  24h0m0s|            1|        false|

then when you're writing points to restoring_rp InfluxDB might response like that:
```
{"error":"partial write: points beyond retention policy dropped=1"}
```
with HTTP 400 status. I believe that it would be pretty okay to skip these particular errors in order not to retry them.

Surely, you can fix this problem by passing _dump-since_ argument while running this script

- improved last_error text. Now it has error status along with error text.